### PR TITLE
deployed backend service 

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.main.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/bitcoin_trading_simulation.iml" filepath="$PROJECT_DIR$/.idea/bitcoin_trading_simulation.iml" />
     </modules>
   </component>

--- a/.idea/modules/backend.main.iml
+++ b/.idea/modules/backend.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../backend/build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../backend/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,8 @@ COPY gradle /app/gradle
 COPY . /app
 
 RUN chmod +x gradlew
-RUN ./gradlew build
 
-CMD ["./gradlew", "bootRun"]
+# 캐시 문제 방지를 위해 clean build + 데몬 비활성화
+RUN ./gradlew clean build --no-daemon
+
+CMD ["./gradlew", "bootRun", "--no-daemon"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,9 @@
-FROM eclipse-temurin:17-jdk
-
+FROM gradle:8.5-jdk17 AS builder
 WORKDIR /app
-
-COPY build.gradle settings.gradle gradlew /app/
-COPY gradle /app/gradle
-COPY . /app
-
-RUN chmod +x gradlew
-
-# 캐시 문제 방지를 위해 clean build + 데몬 비활성화
+COPY --chown=gradle:gradle . .
 RUN ./gradlew clean build --no-daemon
 
-CMD ["./gradlew", "bootRun", "--no-daemon"]
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mock-investment/src/pages/index.tsx
+++ b/mock-investment/src/pages/index.tsx
@@ -18,9 +18,9 @@ export default function Home() {
   // API에서 받아올 시세 정보 저장
   const [ticker, setTicker] = useState<any>(null);
 
-  // 페이지 로드 시 API 호출 => 백엔드에서 구현한 ticker 호출
+  // 페이지 로드 시 API 호출 => 백엔드에서 구현한 ticker 호출 (render 에서 배포 완료!)
   useEffect(() => {
-    fetch("http://localhost:8080/api/ticker?market=KRW-BTC")
+    fetch("https://bitcoin-trading-simulation.onrender.com/api/ticker?market=KRW-BTC")
         .then((res) => res.json())
         .then((data) => setTicker(data))
         .catch((err) => console.error("백엔드 fetch 실패:", err));


### PR DESCRIPTION
render 에서 backend 배포를 완료했고, [swagger](https://bitcoin-trading-simulation.onrender.com/swagger-ui/index.html) 에서 ticker 잘 작동하고 있는 것을 확인할 수 있습니다. 

index.tsx 에서 호출하는 url 경로를 원래 제 localhost 로 해서 테스트했었습니다. 
이제 경로를 render 에서 배포되는 기본 주소인 https://bitcoin-trading-simulation.onrender.com 에서 url 경로인 /api/ticker 로 바꿨습니다.  프론트엔드 mock-investment 디렉터리에서 $npm ren dev 를 실행해서 정상적으로 작동하는 것까지 확인했습니다.

(바뀌는 부분)
index.tsx 파일에서 백엔드를 호출하는 useEffect() 메서드의 fetch 부분 수정

fetch("http://localhost:8080/api/ticker?market=KRW-BTC")         =>
fetch("https://bitcoin-trading-simulation.onrender.com/api/ticker?market=KRW-BTC")